### PR TITLE
feat: mediateka show collection (template_id 59)

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,23 @@
+# LRT Mobile
+
+The LRT.lt React Native app for Lithuanian public broadcasting. This glossary captures domain terms whose meaning is easy to confuse, so code and conversation use one agreed word per concept.
+
+## Language
+
+### Mediateka
+
+**Show**:
+A recurring video programme such as Panorama or Virtuvėje su Beata. A show owns many episodes over time and is represented in the feed as a category.
+_Avoid_: Category (overloaded — see below), programme, laida in code identifiers
+
+**Episode**:
+A single dated video record of a Show (one broadcast/recording). The newest episode of a Show is its "latest item".
+_Avoid_: Article, record, item, įrašas in code identifiers
+
+**Show Collection**:
+A curated, horizontally scrolling row of Shows (not episodes), each shown as a vertical poster. Tapping a poster opens that Show's latest Episode. Distinct from an episode row, which lists Episodes directly.
+_Avoid_: Category collection, laidų kolekcija in code identifiers
+
+**Category**:
+An ambiguous source term: the backend calls both a Show and an episode grouping a "category". Prefer Show when the thing has episodes beneath it; reserve Category only for an episode-listing block.
+_Avoid_: Using "category" for a Show

--- a/app/api/Types.ts
+++ b/app/api/Types.ts
@@ -480,6 +480,43 @@ export const isMediatekaBlockCategory = (data?: MediatekaBlockType): data is Med
   return a?.template_id === 52 || a?.template_id === 22;
 };
 
+// A single Show inside a Show Collection (template 59). Carries its own
+// vertical poster (category_images.img1) and the latest Episode (LATEST_ITEM).
+export type MediatekaCollectionShow = {
+  title: string;
+  category_url?: string;
+  category_images?: {
+    img1?: {
+      img_path_prefix: string;
+      img_path_postfix: string;
+      img_path: string;
+      w_h: string;
+    };
+  };
+  LATEST_ITEM: ArticleContentMedia;
+};
+
+// 59 - Mediatekos laidų kolekcija: a horizontal row of Shows shown as vertical
+// posters. Tapping a poster opens that Show's latest Episode.
+export type MediatekaBlockVideoCollection = {
+  template_id: 59;
+  is_video_category_collection: 1;
+  video_category_collection: {
+    description: {
+      article_title: string;
+      category_url: string;
+    };
+    category_list: MediatekaCollectionShow[];
+  };
+};
+
+export const isMediatekaBlockVideoCollection = (
+  data?: MediatekaBlockType,
+): data is MediatekaBlockVideoCollection => {
+  const a = data as MediatekaBlockVideoCollection | undefined;
+  return a?.template_id === 59;
+};
+
 export type MediatekaBlockContinue = {
   type: 'continue_watching';
   template_id: 999;
@@ -496,6 +533,7 @@ export type MediatekaBlockType =
   | MediatekaBlockBanner
   | MediatekaBlockSlug
   | MediatekaBlockCategory
+  | MediatekaBlockVideoCollection
   | MediatekaBlockContinue;
 
 export type MediatekaV2DataResponse = {

--- a/app/screens/main/tabScreen/mediateka/MediatekaScreen.tsx
+++ b/app/screens/main/tabScreen/mediateka/MediatekaScreen.tsx
@@ -24,12 +24,14 @@ import {
   isMediatekaBlockCategory,
   isMediatekaBlockContinue,
   isMediatekaBlockSlug,
+  isMediatekaBlockVideoCollection,
   isMediatekaBlockWidget,
   MediatekaBlockType,
 } from '../../../../api/Types';
 import EpikaBlock from '../home/blocks/EpikaBlock/EpikaBlock';
 import MediatekaHero from './components/hero/MediatekaHero';
 import MediatekaHorizontalCategoryList from './components/horizontal_list/MediatekaHorizontalCategoryList';
+import MediatekaCollectionList from './components/collection_list/MediatekaCollectionList';
 import VideoListBlock from '../home/blocks/VideoListBlock/VideoListBlock';
 import {pushArticle} from '../../../../util/NavigationUtils';
 import ContinueRow from '../../../../components/continueRow/ContinueRow';
@@ -37,6 +39,9 @@ import ContinueRow from '../../../../components/continueRow/ContinueRow';
 const WIDGET_ID_HERO = 24;
 const WIDGET_ID_LATEST = 25;
 const WIDGET_ID_POPULAR = 26;
+
+// Shown for a Show in a Show Collection (template 59) when it has no poster image.
+const COLLECTION_PLACEHOLDER_IMAGE = 'https://www.lrt.lt/radioteka-static/images/lrt-placeholder.jpg';
 
 interface Props {
   onScroll?: (event: any) => void;
@@ -201,6 +206,26 @@ const MediatekaScreen: React.FC<React.PropsWithChildren<Props>> = ({onScroll, pa
           />
         );
       }
+    }
+
+    if (isMediatekaBlockVideoCollection(item)) {
+      const {description, category_list} = item.video_category_collection;
+      return (
+        <MediatekaCollectionList
+          title={description.article_title}
+          items={category_list.map((show) => {
+            const img = show.category_images?.img1;
+            return {
+              imageUrl: img?.img_path_prefix
+                ? buildImageUri(IMG_SIZE_L, img.img_path_prefix, img.img_path_postfix)
+                : COLLECTION_PLACEHOLDER_IMAGE,
+            };
+          })}
+          onItemPress={(index) => {
+            pushArticle(navigation, category_list[index].LATEST_ITEM);
+          }}
+        />
+      );
     }
 
     if (isMediatekaBlockSlug(item)) {

--- a/app/screens/main/tabScreen/mediateka/components/collection_list/MediatekaCollectionList.tsx
+++ b/app/screens/main/tabScreen/mediateka/components/collection_list/MediatekaCollectionList.tsx
@@ -1,0 +1,106 @@
+import React, {useEffect, useRef} from 'react';
+import {View, StyleSheet, FlatList, Dimensions} from 'react-native';
+import FastImage from '@d11/react-native-fast-image';
+import Text from '../../../../../../components/text/Text';
+import {TouchableDebounce} from '../../../../../../components';
+import {useTheme} from '../../../../../../Theme';
+
+const CARD_WIDTH = Math.min(Dimensions.get('window').width * 0.53, 240);
+
+export type MediatekaCollectionItem = {
+  imageUrl: string;
+};
+
+interface MediatekaCollectionListProps {
+  title: string;
+  items: MediatekaCollectionItem[];
+  separatorTop?: boolean;
+  onItemPress?: (index: number) => void;
+}
+
+const MediatekaCollectionList: React.FC<MediatekaCollectionListProps> = ({
+  title,
+  items,
+  separatorTop = true,
+  onItemPress,
+}) => {
+  const {colors} = useTheme();
+  const listRef = useRef<FlatList>(null);
+
+  useEffect(() => {
+    if (listRef.current) {
+      listRef.current.scrollToOffset({offset: 0, animated: false});
+    }
+  }, [items]);
+
+  const renderItem = ({item, index}: {item: MediatekaCollectionItem; index: number}) => (
+    <TouchableDebounce style={styles.card} onPress={() => onItemPress?.(index)} activeOpacity={0.8}>
+      <FastImage source={{uri: item.imageUrl}} resizeMode="cover" style={styles.image} />
+    </TouchableDebounce>
+  );
+
+  return (
+    <View style={styles.container}>
+      {separatorTop && (
+        <View style={{height: StyleSheet.hairlineWidth, backgroundColor: colors.listSeparator}} />
+      )}
+      <View style={styles.header}>
+        <Text type="primary" fontFamily="SourceSansPro-SemiBold" style={styles.title}>
+          {title}
+        </Text>
+      </View>
+      <FlatList
+        ref={listRef}
+        data={items}
+        renderItem={renderItem}
+        keyExtractor={(_item, index) => `${index}`}
+        horizontal
+        showsHorizontalScrollIndicator={false}
+        contentContainerStyle={styles.listContainer}
+      />
+    </View>
+  );
+};
+
+const styles = StyleSheet.create({
+  container: {
+    flex: 1,
+    marginBottom: 24,
+  },
+  header: {
+    paddingHorizontal: 16,
+    paddingTop: 12,
+  },
+  title: {
+    fontSize: 20,
+    textTransform: 'uppercase',
+  },
+  listContainer: {
+    paddingVertical: 24,
+    paddingHorizontal: 12,
+    gap: 16,
+  },
+  card: {
+    width: CARD_WIDTH,
+    aspectRatio: 0.7,
+    borderRadius: 8,
+    overflow: 'hidden',
+  },
+  image: {
+    ...StyleSheet.absoluteFill,
+    borderRadius: 8,
+    borderWidth: 1,
+    borderColor: '#FFFFFF',
+    backgroundColor: '#888',
+    shadowColor: '#000',
+    shadowOffset: {
+      width: 0,
+      height: 1,
+    },
+    shadowOpacity: 0.22,
+    shadowRadius: 2.22,
+    elevation: 2,
+  },
+});
+
+export default MediatekaCollectionList;


### PR DESCRIPTION
## What

Implements rendering for the new Mediateka **Show Collection** block (`template_id: 59`, "Mediatekos laidų kolekcija") on the Mediateka tab — a horizontally scrolling row of Shows shown as vertical posters. Tapping a poster opens that Show's latest Episode.

Structurally this is the video analog of RADIOTEKA's existing `audio_category_collection`.

## Changes

- **`app/api/Types.ts`** — new `MediatekaCollectionShow` + `MediatekaBlockVideoCollection` types and `isMediatekaBlockVideoCollection` guard (discriminates on `template_id === 59`); registered in the `MediatekaBlockType` union.
- **`MediatekaCollectionList.tsx`** (new) — presentational horizontal row: uppercase non-clickable header, vertical poster cards (`aspectRatio: 0.7`, cover-cropped), no titles/badges/play button.
- **`MediatekaScreen.tsx`** — new `renderItem` branch mapping each Show to its poster and routing taps to the latest Episode via `pushArticle(…LATEST_ITEM)`.
- **`CONTEXT.md`** (new) — glossary for the Show / Episode / Show Collection / Category distinction.

## Notes

- **Image sizing:** posters are requested at landscape `IMG_SIZE_L` and cover-cropped into the portrait card, because the CDN only serves predefined landscape derivatives — arbitrary portrait sizes 404. If a portrait derivative is added backend-side, swap the size and drop the crop.
- **Missing image fallback:** Shows without `category_images.img1` fall back to `https://www.lrt.lt/radioteka-static/images/lrt-placeholder.jpg`.
- Verified against live `category-home?id=672`: both template-59 blocks render ("Aktualijos", "Mediatekos laisvalaikis"), and the placeholder path is exercised by real shows with missing images.

## Testing

- `yarn ts` passes clean.
- `yarn lint` is broken repo-wide (ESLint can't resolve `jest/globals` in `.eslintrc.js`) — pre-existing, unrelated to this change.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
