### PR TITLE
fix: preserve history order

### DIFF
--- a/CONTEXT.md
+++ b/CONTEXT.md
@@ -1,0 +1,13 @@
+# LRT Mobile App
+
+The LRT.lt React Native app for Lithuanian public broadcasting: news articles, live TV/radio, podcasts, videos, and weather.
+
+## Language
+
+**History**:
+The list of articles a user has opened, ordered by most-recently-opened first. Opening an article (including one already in History) moves it to the top.
+_Avoid_: Viewed articles, recently read
+
+**Saved Article**:
+An article the user has explicitly bookmarked for later. Distinct from History — saving is deliberate, History is automatic.
+_Avoid_: Bookmark, favorite (in storage-layer naming)

--- a/app/api/hooks/useHistoryArticles.ts
+++ b/app/api/hooks/useHistoryArticles.ts
@@ -42,8 +42,28 @@ export const useHistoryUserArticles = (page: number, count?: number) => {
     enabled: !!user,
   });
 
-  const articleIds = HttpClient.isAuthenticated() ? data : localHistoryArticleIds;
+  // For authenticated users the displayed order comes from the server list. Overlay
+  // the local store's recency order so a just-opened article jumps to the top on this
+  // device regardless of how/whether the backend bumps its position (see ADR-0001).
+  // IDs only known to the server (older items, other devices) keep their server order.
+  const articleIds = HttpClient.isAuthenticated() ? overlayLocalOrder(data, history) : localHistoryArticleIds;
   return useSearchArticlesByIds(articleIds);
+};
+
+const overlayLocalOrder = (
+  serverIds: number[] | undefined,
+  localHistory: ReturnType<typeof useArticleStorageStore.getState>['history'],
+): number[] | undefined => {
+  if (!serverIds) {
+    return serverIds;
+  }
+  const localRank = new Map(
+    localHistory.map((item, index) => [isMediaArticle(item) ? item.id : item.article_id, index]),
+  );
+  return [...serverIds].sort(
+    (a, b) =>
+      (localRank.get(a) ?? Number.MAX_SAFE_INTEGER) - (localRank.get(b) ?? Number.MAX_SAFE_INTEGER),
+  );
 };
 
 export const useAddHistoryUserArticle = () =>

--- a/app/api/hooks/useSearchArticles.ts
+++ b/app/api/hooks/useSearchArticles.ts
@@ -24,7 +24,18 @@ export const useSearchArticlesByIds = (ids?: string[] | number[]) =>
           signal,
         },
       );
-      return response;
+
+      // The search endpoint returns items in its own order (by date), ignoring the
+      // order of the requested ids. Callers pass an intentionally-ordered id list
+      // (history recency, saved order, recommendation rank), so reorder the items to
+      // match the requested ids. Items missing from the response are simply absent.
+      const orderById = new Map(articleIds.map((id, index) => [String(id), index]));
+      const items = [...response.items].sort(
+        (a, b) =>
+          (orderById.get(String(a.id)) ?? Number.MAX_SAFE_INTEGER) -
+          (orderById.get(String(b.id)) ?? Number.MAX_SAFE_INTEGER),
+      );
+      return {...response, items};
     },
     enabled: !!ids,
     placeholderData: keepPreviousData,

--- a/docs/adr/0001-history-ordering-local-overlay.md
+++ b/docs/adr/0001-history-ordering-local-overlay.md
@@ -1,0 +1,9 @@
+# History ordering: local store overlaid on server list
+
+For authenticated users, the reading **History** list is ordered by most-recently-opened. The order is driven by the local device store overlaid on the server's history list — not purely by the server — because the backend's `PUT /authrz/user/history/{id}` bump behavior (whether re-opening an already-stored article refreshes its `added_at`) is unverified. The local store (`useArticleStorageStore`) is updated on every article open, so overlaying its recency order guarantees a just-opened article jumps to the top on the device the user is tapping, regardless of how the backend orders its response.
+
+## Consequences
+
+- Local and server can momentarily disagree (e.g. an article opened on another device sorts by its server timestamp, not "now"); invisible for single-device use.
+- IDs beyond the local cap or only present server-side keep their server order.
+- If the backend is later confirmed to bump `added_at`, the overlay and server converge — the overlay stays correct either way, so it's safe to keep.


### PR DESCRIPTION
## Summary

This branch contains two changes:

### 1. Reading-history ordering (most-recently-opened)
Opening an article from History now moves it to the top of the list when you return — for both authenticated and anonymous users.

- **`useSearchArticlesByIds`** now reorders `response.items` to match the requested ID order. The `/api/json/search?ids=` endpoint returned items in its own order (by date), discarding the caller's intended order. Callers pass intentionally-ordered ID lists (history recency, saved order, recommendation rank), so this fixes History, Favorites, Continue-playing, and Recommendations consistently. Items missing from the response are simply absent; unrequested items sort to the end.
- **`useHistoryUserArticles`** now overlays the local store's recency order on the server ID list for authenticated users, so a just-opened article jumps to the top on-device regardless of whether the backend bumps its position. IDs known only to the server keep their server order (stable sort). Anonymous users already use the local list directly. See `docs/adr/0001-history-ordering-local-overlay.md`.

Open follow-up: confirm whether `PUT /authrz/user/history/{id}` refreshes `added_at`. If it does, server and overlay converge; if not, the overlay keeps us correct on-device either way.

### 2. Mediateka "Show Collection" (template 59) removal
Removes the template-59 Show Collection block: deletes `MediatekaCollectionList`, drops `MediatekaBlockVideoCollection`/`MediatekaCollectionShow` types and the `isMediatekaBlockVideoCollection` guard, and removes the block from `MediatekaScreen`.

### Docs
- Adds `CONTEXT.md` glossary (History, Saved Article) and ADR-0001.

## Test plan
- [ ] Open an article from History (logged in) → it appears at the top on return
- [ ] Open an article from History (logged out) → it appears at the top on return
- [ ] Favorites / Continue-playing / Recommendations still render in their expected order
- [ ] Mediateka renders without the removed template-59 block

🤖 Generated with [Claude Code](https://claude.com/claude-code)