### PR TITLE
chore: bump react-native-auth0 to ^5.9.0

### DIFF
--- a/package.json
+++ b/package.json
@@ -41,7 +41,7 @@
     "moment": "^2.30.1",
     "react": "19.2.3",
     "react-native": "0.86.0",
-    "react-native-auth0": "^5.7.0",
+    "react-native-auth0": "^5.9.0",
     "react-native-autoheight-webview": "^1.6.5",
     "react-native-config": "^1.6.1",
     "react-native-event-listeners": "^1.0.7",


### PR DESCRIPTION
Bumps `react-native-auth0` from ^5.7.0 to ^5.9.0. The yarn.lock already resolves to 5.9.0.

🤖 Generated with [Claude Code](https://claude.com/claude-code)