### PR TITLE
feat: dark mode support for HTML embeds

### DIFF
--- a/app/components/articleParagraphs/embeded/embedComponents/EmbedHTML.tsx
+++ b/app/components/articleParagraphs/embeded/embedComponents/EmbedHTML.tsx
@@ -5,30 +5,36 @@ import WebView from 'react-native-webview';
 
 import {ArticleEmbedHTMLType} from '../../../../api/Types';
 import SafeAutoHeightWebView from '../../../safeWebView/SafeAutoHeightWebView';
-import {extractBlockedIframeSrc, WIDTH_REGEX} from './embedHtmlUtils';
+import {
+  applyDarkThemeToEmbedHtml,
+  applyDarkThemeToEmbedSrc,
+  extractBlockedIframeSrc,
+  WIDTH_REGEX,
+} from './embedHtmlUtils';
+import {useTheme} from '../../../../Theme';
 
 interface Props {
   data: ArticleEmbedHTMLType[];
 }
 
 const EmbedHTML: React.FC<React.PropsWithChildren<Props>> = ({data}) => {
+  const {dark: isDarkMode, colors} = useTheme();
   const [initialWidth, setInitialWidth] = useState(0);
   const [currentWidth, setCurrentWidth] = useState(0);
   const webViewRefs = useRef<Map<number, WebView>>(new Map());
   const initializedRef = useRef(false);
 
-  const onLayout = useCallback(
-    (event: {nativeEvent: {layout: {width: number; height: number}}}) => {
-      const newWidth = event.nativeEvent.layout.width;
-      setCurrentWidth(newWidth);
+  const onLayout = useCallback((event: {nativeEvent: {layout: {width: number; height: number}}}) => {
+    const newWidth = event.nativeEvent.layout.width;
+    setCurrentWidth(newWidth);
 
-      if (!initializedRef.current && newWidth > 0) {
-        setInitialWidth(newWidth);
-        initializedRef.current = true;
-      } else if (initializedRef.current && newWidth > 0) {
-        // Orientation changed — inject JS to resize content without reloading
-        webViewRefs.current.forEach((webView) => {
-          webView?.injectJavaScript(`
+    if (!initializedRef.current && newWidth > 0) {
+      setInitialWidth(newWidth);
+      initializedRef.current = true;
+    } else if (initializedRef.current && newWidth > 0) {
+      // Orientation changed — inject JS to resize content without reloading
+      webViewRefs.current.forEach((webView) => {
+        webView?.injectJavaScript(`
             (function() {
               document.querySelectorAll('iframe').forEach(function(iframe) {
                 iframe.style.width = '${newWidth}px';
@@ -44,11 +50,9 @@ const EmbedHTML: React.FC<React.PropsWithChildren<Props>> = ({data}) => {
             })();
             true;
           `);
-        });
-      }
-    },
-    [],
-  );
+      });
+    }
+  }, []);
 
   const width = initialWidth;
   return (
@@ -69,7 +73,7 @@ const EmbedHTML: React.FC<React.PropsWithChildren<Props>> = ({data}) => {
 
             if (src) {
               source = {
-                uri: src,
+                uri: isDarkMode ? applyDarkThemeToEmbedSrc(src) : src,
               };
             } else if (html) {
               // Load iframe src directly: avoids ERR_BLOCKED_BY_RESPONSE on Android
@@ -77,7 +81,7 @@ const EmbedHTML: React.FC<React.PropsWithChildren<Props>> = ({data}) => {
               const iframeSrc = extractBlockedIframeSrc(html);
               if (iframeSrc) {
                 source = {
-                  uri: iframeSrc,
+                  uri: isDarkMode ? applyDarkThemeToEmbedSrc(iframeSrc) : iframeSrc,
                 };
               } else {
                 let formattedHTML = html
@@ -88,6 +92,13 @@ const EmbedHTML: React.FC<React.PropsWithChildren<Props>> = ({data}) => {
                 const trimmed = formattedHTML.trim();
                 if (trimmed.startsWith('<script') && !/<(?!script|\/script)\w/i.test(trimmed)) {
                   formattedHTML = `<html><body>${formattedHTML}</body></html>`;
+                }
+
+                if (isDarkMode) {
+                  formattedHTML = applyDarkThemeToEmbedHtml(formattedHTML, {
+                    background: colors.background,
+                    text: colors.text,
+                  });
                 }
 
                 source = {
@@ -124,6 +135,7 @@ const EmbedHTML: React.FC<React.PropsWithChildren<Props>> = ({data}) => {
                 startInLoadingState={true}
                 viewportContent={`width=${width}, user-scalable=no`}
                 source={source}
+                allowDarkMode
                 openLinksExternally
               />
             );

--- a/app/components/articleParagraphs/embeded/embedComponents/embedHtmlUtils.ts
+++ b/app/components/articleParagraphs/embeded/embedComponents/embedHtmlUtils.ts
@@ -26,7 +26,16 @@ export const applyDarkThemeToEmbedSrc = (src: string): string => {
   if (/(platform\.twitter\.com|platform\.x\.com)/.test(src) && !/[?&]theme=/.test(src)) {
     return `${src}${separator}theme=dark`;
   }
-  if (src.includes('datawrapper.dwcdn.net') && !/[?&]dark=/.test(src)) {
+
+  let isDatawrapperHost = false;
+  try {
+    const parsedUrl = new URL(src);
+    isDatawrapperHost = parsedUrl.hostname === 'datawrapper.dwcdn.net';
+  } catch {
+    isDatawrapperHost = false;
+  }
+
+  if (isDatawrapperHost && !/[?&]dark=/.test(src)) {
     return `${src}${separator}dark=true`;
   }
   return src;

--- a/app/components/articleParagraphs/embeded/embedComponents/embedHtmlUtils.ts
+++ b/app/components/articleParagraphs/embeded/embedComponents/embedHtmlUtils.ts
@@ -16,3 +16,45 @@ export const extractBlockedIframeSrc = (html: string): string | null => {
 };
 
 export const WIDTH_REGEX = /width\s*=\s*["']?\b(\d{3,4})\b["']?/gi;
+
+/**
+ * Injected CSS can't cross iframe boundaries, so dark mode has to be requested
+ * through each provider's own theme parameter.
+ */
+export const applyDarkThemeToEmbedSrc = (src: string): string => {
+  const separator = src.includes('?') ? '&' : '?';
+  if (/(platform\.twitter\.com|platform\.x\.com)/.test(src) && !/[?&]theme=/.test(src)) {
+    return `${src}${separator}theme=dark`;
+  }
+  if (src.includes('datawrapper.dwcdn.net') && !/[?&]dark=/.test(src)) {
+    return `${src}${separator}dark=true`;
+  }
+  return src;
+};
+
+export type EmbedThemeColors = {
+  background: string;
+  text: string;
+};
+
+export const applyDarkThemeToEmbedHtml = (html: string, colors: EmbedThemeColors): string => {
+  const themedHtml = html
+    // Twitter/X blockquote embeds pick the theme from a data attribute
+    .replace(/<blockquote([^>]*class=["'][^"']*twitter-tweet[^"']*["'][^>]*)>/gi, (match, attrs) =>
+      attrs.includes('data-theme') ? match : `<blockquote${attrs} data-theme="dark">`,
+    )
+    .replace(
+      /(<iframe[^>]+src=["'])([^"']+)(["'])/gi,
+      (_match, prefix, src, suffix) => `${prefix}${applyDarkThemeToEmbedSrc(src)}${suffix}`,
+    );
+
+  // Plain HTML fragments (text, links) render black-on-white by default.
+  // color-scheme lets the engine adjust UA defaults (links, form controls) too.
+  const darkBaseStyle =
+    '<style>' +
+    ':root { color-scheme: dark; }' +
+    `body { background-color: ${colors.background}; color: ${colors.text}; }` +
+    '</style>';
+
+  return `${darkBaseStyle}${themedHtml}`;
+};

--- a/app/components/htmlRenderer/HTMLRenderer.tsx
+++ b/app/components/htmlRenderer/HTMLRenderer.tsx
@@ -162,6 +162,7 @@ const useTagStyles = (): Record<string, MixedStyleDeclaration> => {
     () => ({
       p: {
         paddingVertical: 4,
+        marginVertical: 8,
         alignSelf: 'center',
         minWidth: '100%',
       },


### PR DESCRIPTION
## Summary

Article HTML embeds (`EmbedHTML`) previously always rendered light, which was jarring in dark mode. This PR forces dark rendering through three complementary mechanisms:

- **Native WebView darkening (Android)**: pass `allowDarkMode` to `SafeAutoHeightWebView`, enabling `forceDarkOn` when the app theme is dark.
- **Provider theme parameters**: new `applyDarkThemeToEmbedSrc` / `applyDarkThemeToEmbedHtml` utils rewrite known embeds to request their own dark theme — `theme=dark` for Twitter/X (`platform.twitter.com` / `platform.x.com` iframes and `data-theme="dark"` on `twitter-tweet` blockquotes), `dark=true` for Datawrapper charts. Injected CSS can't cross iframe boundaries, so this is the only reliable way to darken third-party iframe content (works on iOS too).
- **Inline HTML fragments**: plain fragments (e.g. a `<p>` with a link) get a prepended base stylesheet using the app's dark theme colors (`#141a21` background, `#F9F9F9` text) plus `color-scheme: dark` so UA defaults (link colors, form controls) adapt as well.

Dark handling is driven by `useTheme()`, so it also respects `forceTheme` from `ThemeProvider`.

Also includes a small spacing tweak in `HTMLRenderer`: `marginVertical: 8` on `p` tags.

## Notes

- The dark base stylesheet is prepended *after* the script-only `<html><body>` wrapping check, so script-only embeds still get wrapped correctly.
- Toggling the theme while an article is open reloads embeds (the WebView `source` changes) — expected, since a themed embed must be re-requested.
- Providers without a theme parameter (Instagram, Facebook) still render light on iOS; Android darkens them best-effort via `forceDarkOn`.

## Test plan

- [ ] Open an article with a Twitter/X embed in dark mode → tweet renders dark
- [ ] Open an article with a plain HTML fragment embed (e.g. weather link paragraph) in dark mode → light text on app-dark background
- [ ] Same articles in light mode → unchanged
- [ ] Toggle dark mode with an article open → embeds reload with the new theme

🤖 Generated with [Claude Code](https://claude.com/claude-code)