### PR TITLE
fix: stop playback when PiP window is dismissed

### DIFF
--- a/app/components/videoComponent/TheoMediaPlayer.tsx
+++ b/app/components/videoComponent/TheoMediaPlayer.tsx
@@ -27,6 +27,7 @@ import Config from 'react-native-config';
 import usePlayerOrientationChange from './usePlayerOrientationChange';
 import {PlayerContextProvider} from './context/player/PlayerContextProvider';
 import usePlayerBackListener from './usePlayerBackListener';
+import usePlayerPipListener from './usePlayerPipListener';
 import usePlayerSubtitles from './ui/extra/usePlayerSubtitles';
 import usePlayerLoop from './usePlayerLoop';
 import usePlayerFullScreen from './usePlayerFullScreen';
@@ -141,6 +142,9 @@ const TheoMediaPlayer: React.FC<React.PropsWithChildren<Props>> = ({
 
   // Set up back button handler
   usePlayerBackListener({player});
+
+  // Stop playback when PiP window is dismissed
+  usePlayerPipListener({player});
 
   // Set up looping
   usePlayerLoop({player, loop});

--- a/app/components/videoComponent/usePlayerPipListener.ts
+++ b/app/components/videoComponent/usePlayerPipListener.ts
@@ -1,0 +1,36 @@
+import {useEffect} from 'react';
+import {
+  PlayerEventType,
+  PresentationModeChangeEvent,
+  PresentationModeChangePipContext,
+  THEOplayer,
+} from 'react-native-theoplayer';
+import {log, getCrashlytics} from '@react-native-firebase/crashlytics';
+
+interface UsePlayerPipListenerParams {
+  player: THEOplayer | undefined;
+}
+
+/**
+ * Stops playback when the user explicitly dismisses the PiP window,
+ * otherwise audio keeps playing due to backgroundAudioConfiguration.
+ */
+const usePlayerPipListener = ({player}: UsePlayerPipListenerParams) => {
+  useEffect(() => {
+    if (!player) return;
+
+    const onPresentationModeChange = (event: PresentationModeChangeEvent) => {
+      if (event.context?.pip === PresentationModeChangePipContext.CLOSED) {
+        log(getCrashlytics(), 'TheoMediaPlayer: PiP window dismissed, stopping playback');
+        player.pause();
+      }
+    };
+
+    player.addEventListener(PlayerEventType.PRESENTATIONMODE_CHANGE, onPresentationModeChange);
+    return () => {
+      player.removeEventListener(PlayerEventType.PRESENTATIONMODE_CHANGE, onPresentationModeChange);
+    };
+  }, [player]);
+};
+
+export default usePlayerPipListener;


### PR DESCRIPTION
## Summary
- Add `usePlayerPipListener` hook that listens for `PRESENTATIONMODE_CHANGE` events on the THEOplayer instance
- When the PiP window is dismissed by the user (`PresentationModeChangePipContext.CLOSED`), playback is paused — previously audio kept playing because `backgroundAudioConfiguration` keeps the audio session alive
- Logs the event to Crashlytics for observability

## Test plan
- Start video playback, enter PiP mode, dismiss the PiP window → playback (including audio) should stop
- Restore PiP back to fullscreen/inline → playback should continue as before

🤖 Generated with [Claude Code](https://claude.com/claude-code)